### PR TITLE
Remove pidof as it is deprecated on several distros

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -242,11 +242,17 @@ function killSniper($artnr,$db) {
 }
 
 function getPids() {
-    $output = shell_exec("pidof -x esniperstart.sh");
-    if ($output != "\n") {
-    	$pids = explode(" ",rtrim($output));
-    }
-    return($pids);
+    #pidof was removed on several distros
+    #$output = shell_exec("pidof -x esniperstart.sh");
+    #if ($output != "\n") {
+    #	$pids = explode(" ",rtrim($output));
+    #}
+
+    $output = trim(shell_exec('ps -ef | grep esniperstart.sh'));
+    if($output == '') return array();
+
+    preg_match_all('#[^ ]+\s+(\d+)\s+\d+\s+\d+\s+[^ ]+\s+[^ ]+\s+\d{2}:\d{2}:\d{2}\s/bin/sh ./esniperstart.sh#', $output, $match);
+    return $match[1];
 }
 
 


### PR DESCRIPTION
Pidof is no longer available on some distros like Gentoo - this will replace the use of "pidof" with some "ps/grep"-Variant.

Note: While it should work on most distros I only tested Gentoo so far

Note: Original returns uninitialized variable if no processes are found.
